### PR TITLE
Update voxel_collision_checker.cpp

### DIFF
--- a/src/trajopt/voxel_collision_checker.cpp
+++ b/src/trajopt/voxel_collision_checker.cpp
@@ -24,7 +24,7 @@ public:
   static boost::shared_ptr<CollisionChecker> GetOrCreate(OR::EnvironmentBase& env);
 };
 
-}
+// }
 
 /**
 Approximate each link as a union of spheres


### PR DESCRIPTION
On line 27 there is an invalid number of characters '{', which is an error.

Found by https://github.com/bryongloden/cppcheck
